### PR TITLE
Make read transaction able to commit

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -137,6 +137,8 @@ impl Env {
 
         match result {
             Ok(()) => {
+                rtxn.commit()?;
+
                 let old_types = lock.entry(dbi).or_insert(types);
 
                 if *old_types == types {


### PR DESCRIPTION
If we do not commit database openings, the dbi is private to the transaction, so, even for a read transaction we must commit databases openings.