### PR TITLE
Bump `-sys` crates and heed/heed3 versions

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "A fully typed LMDB (mdb.master) wrapper with minimum overhead"
 license = "MIT"
@@ -25,7 +25,7 @@ byteorder = { version = "1.5.0", default-features = false }
 heed-traits = { version = "0.20.0", path = "../heed-traits" }
 heed-types = { version = "0.21.0", default-features = false, path = "../heed-types" }
 libc = "0.2.170"
-lmdb-master-sys = { version = "0.2.4", path = "../lmdb-master-sys" }
+lmdb-master-sys = { version = "0.2.5", path = "../lmdb-master-sys" }
 once_cell = "1.20.3"
 page_size = "0.6.0"
 serde = { version = "1.0.218", features = ["derive"], optional = true }

--- a/heed3/Cargo.toml
+++ b/heed3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed3"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "A fully typed LMDB (mdb.master3) wrapper with minimum overhead with support for encryption"
 license = "MIT"
@@ -19,7 +19,7 @@ generic-array = { version = "0.14.7", features = ["serde"] }
 heed-traits = { version = "0.20.0", path = "../heed-traits" }
 heed-types = { version = "0.21.0", default-features = false, path = "../heed-types" }
 libc = "0.2.169"
-lmdb-master3-sys = { version = "0.2.4", path = "../lmdb-master3-sys" }
+lmdb-master3-sys = { version = "0.2.5", path = "../lmdb-master3-sys" }
 once_cell = "1.20.2"
 page_size = "0.6.0"
 serde = { version = "1.0.217", features = ["derive"], optional = true }

--- a/lmdb-master-sys/Cargo.toml
+++ b/lmdb-master-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lmdb-master-sys"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.2.4"
+version = "0.2.5"
 authors = [
     "Kerollmops <clement@meilisearch.com>",
     "Dan Burkert <dan@danburkert.com>",

--- a/lmdb-master-sys/src/lib.rs
+++ b/lmdb-master-sys/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(rustdoc::invalid_html_tags)]
 #![allow(non_camel_case_types)]
 #![allow(clippy::all)]
-#![doc(html_root_url = "https://docs.rs/lmdb-master-sys/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/lmdb-master-sys/0.2.5")]
 
 extern crate libc;
 

--- a/lmdb-master3-sys/Cargo.toml
+++ b/lmdb-master3-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lmdb-master3-sys"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.2.4"
+version = "0.2.5"
 authors = [
     "Kerollmops <clement@meilisearch.com>",
     "Dan Burkert <dan@danburkert.com>",

--- a/lmdb-master3-sys/src/lib.rs
+++ b/lmdb-master3-sys/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(rustdoc::invalid_html_tags)]
 #![allow(non_camel_case_types)]
 #![allow(clippy::all)]
-#![doc(html_root_url = "https://docs.rs/lmdb-master-sys/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/lmdb-master-sys/0.2.5")]
 
 extern crate libc;
 


### PR DESCRIPTION
This PR fixes #323 by bumping the _mdb-master-sys_, _mdb-master3-sys_, _heed_, and _heed3_ versions.