### PR TITLE
Safer API for RwIter

### DIFF
--- a/heed/src/databases/database.rs
+++ b/heed/src/databases/database.rs
@@ -1069,16 +1069,16 @@ impl<KC, DC, C, CDUP> Database<KC, DC, C, CDUP> {
     /// db.put(&mut wtxn, &13, "i-am-thirteen")?;
     ///
     /// let mut iter = db.iter_mut(&mut wtxn)?;
-    /// assert_eq!(iter.next().transpose()?, Some((13, "i-am-thirteen")));
+    /// assert_eq!(Iterator::next(&mut iter).transpose()?, Some((13, "i-am-thirteen")));
     /// let ret = unsafe { iter.del_current()? };
     /// assert!(ret);
     ///
-    /// assert_eq!(iter.next().transpose()?, Some((27, "i-am-twenty-seven")));
-    /// assert_eq!(iter.next().transpose()?, Some((42, "i-am-forty-two")));
+    /// assert_eq!(Iterator::next(&mut iter).transpose()?, Some((27, "i-am-twenty-seven")));
+    /// assert_eq!(Iterator::next(&mut iter).transpose()?, Some((42, "i-am-forty-two")));
     /// let ret = unsafe { iter.put_current(&42, "i-am-the-new-forty-two")? };
     /// assert!(ret);
     ///
-    /// assert_eq!(iter.next().transpose()?, None);
+    /// assert_eq!(Iterator::next(&mut iter).transpose()?, None);
     ///
     /// drop(iter);
     ///

--- a/heed/src/databases/encrypted_database.rs
+++ b/heed/src/databases/encrypted_database.rs
@@ -914,16 +914,16 @@ impl<KC, DC, C, CDUP> EncryptedDatabase<KC, DC, C, CDUP> {
     /// db.put(&mut wtxn, &13, "i-am-thirteen")?;
     ///
     /// let mut iter = db.iter_mut(&mut wtxn)?;
-    /// assert_eq!(iter.next().transpose()?, Some((13, "i-am-thirteen")));
+    /// assert_eq!(Iterator::next(&mut iter).transpose()?, Some((13, "i-am-thirteen")));
     /// let ret = unsafe { iter.del_current()? };
     /// assert!(ret);
     ///
-    /// assert_eq!(iter.next().transpose()?, Some((27, "i-am-twenty-seven")));
-    /// assert_eq!(iter.next().transpose()?, Some((42, "i-am-forty-two")));
+    /// assert_eq!(Iterator::next(&mut iter).transpose()?, Some((27, "i-am-twenty-seven")));
+    /// assert_eq!(Iterator::next(&mut iter).transpose()?, Some((42, "i-am-forty-two")));
     /// let ret = unsafe { iter.put_current(&42, "i-am-the-new-forty-two")? };
     /// assert!(ret);
     ///
-    /// assert_eq!(iter.next().transpose()?, None);
+    /// assert_eq!(Iterator::next(&mut iter).transpose()?, None);
     ///
     /// drop(iter);
     ///


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This PR introduces a safer API for `RwIter`, as a lending iterator.

It is not possible to keep a reference to the key or data at the current cursor after deleting or inserting at the current cursor. If one chooses not to insert or delete at the current cursor, it is possible to keep a reference to the key or data until the end of the current transaction.
It is only possible to insert at the current cursor with the exact key for the current cursor, which is always owned when inserting. It is not possible to insert at the current cursor after deleting at the current cursor, although it is possible to insert multiple times at the current cursor. It is only possible to insert or delete at the current cursor once the cursor has been initialized via a call to `RwIter::next` or `RwIter::last`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
