### PR TITLE
add custom bytes range query to cookbook

### DIFF
--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -592,12 +592,10 @@
 //!
 //! ```
 //! use std::error::Error;
-//! use std::fs;
-//! use std::path::Path;
 //!
 //! use heed::byteorder::NativeEndian;
 //! use heed::types::*;
-//! use heed::{Database, DatabaseFlags, EnvOpenOptions};
+//! use heed::EnvOpenOptions;
 //!
 //! fn main() -> Result<(), Box<dyn Error>> {
 //!     let path = tempfile::tempdir()?;
@@ -626,7 +624,7 @@
 //!     let txn = env.read_txn()?;
 //!     let key: Vec<u8> = vec![1, 2, 3, 4];
 //!
-//!     for res in db
+//!     for result in db
 //!         .range(
 //!             &txn,
 //!             &(


### PR DESCRIPTION
## Related issue
Fixes https://github.com/meilisearch/heed/issues/346#issuecomment-3384574726

## What does this PR do?
- adds an example of how to use a custom `RangeBounds` implementation with `Vec<u8>` keys to the cookbook.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?