### PR TITLE
Add method to get a value from a key/value

### DIFF
--- a/heed/src/cursor.rs
+++ b/heed/src/cursor.rs
@@ -145,7 +145,7 @@ impl<'txn> RoCursor<'txn> {
         }
     }
 
-    pub fn move_on_key_value(&mut self, key: &[u8], data: &[u8]) -> Result<bool> {
+    pub fn move_on_key_value(&mut self, key: &[u8], data: &[u8]) -> Result<Option<&'txn [u8]>> {
         let mut key_val = unsafe { crate::into_val(key) };
         let mut data_val = unsafe { crate::into_val(data) };
 
@@ -160,8 +160,8 @@ impl<'txn> RoCursor<'txn> {
         };
 
         match result {
-            Ok(()) => Ok(true),
-            Err(e) if e.not_found() => Ok(false),
+            Ok(()) => Ok(Some(unsafe { crate::from_val(data_val) })),
+            Err(e) if e.not_found() => Ok(None),
             Err(e) => Err(e.into()),
         }
     }

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -33,6 +33,7 @@ pub mod cursor_op {
     pub const MDB_NEXT_NODUP: MDB_cursor_op = ffi::MDB_NEXT_NODUP;
     pub const MDB_NEXT_DUP: MDB_cursor_op = ffi::MDB_NEXT_DUP;
     pub const MDB_GET_CURRENT: MDB_cursor_op = ffi::MDB_GET_CURRENT;
+    pub const MDB_GET_BOTH: MDB_cursor_op = ffi::MDB_GET_BOTH;
 }
 
 pub fn reserve_size_val(size: usize) -> ffi::MDB_val {


### PR DESCRIPTION
# Pull Request

## What does this PR do?

Adds a method to get a value from a (key, value). Although on the surface this may seem useless, if you define the values comparison function to only take into account part of the value then you can use this method to do direct lookups of multi-map values.

This method would probably be less necessary if we exposed Cursors, which I would like, however this is a much smaller change and fits my use-case. 



