### PR TITLE
fix `last` on iterators with dup values

### DIFF
--- a/heed/src/databases/database.rs
+++ b/heed/src/databases/database.rs
@@ -434,6 +434,7 @@ impl<KC, DC, C, CDUP> Database<KC, DC, C, CDUP> {
     /// drop(iter);
     ///
     /// let mut iter = db.get_duplicates(&wtxn, &68)?.expect("the key exists");
+    /// assert_eq!(iter.next().transpose()?, Some((68, 120)));
     /// assert_eq!(iter.last().transpose()?, Some((68, 123)));
     ///
     /// wtxn.commit()?;

--- a/heed/src/iterator/iter.rs
+++ b/heed/src/iterator/iter.rs
@@ -179,17 +179,7 @@ where
     }
 
     fn last(mut self) -> Option<Self::Item> {
-        let result = if self.move_on_first {
-            self.cursor.move_on_last(IM::MOVE_OPERATION)
-        } else {
-            match (self.cursor.current(), self.cursor.move_on_last(IM::MOVE_OPERATION)) {
-                (Ok(Some((ckey, _))), Ok(Some((key, data)))) if ckey != key => {
-                    Ok(Some((key, data)))
-                }
-                (Ok(_), Ok(_)) => Ok(None),
-                (Err(e), _) | (_, Err(e)) => Err(e),
-            }
-        };
+        let result = self.cursor.move_on_last(IM::MOVE_OPERATION);
 
         match result {
             Ok(Some((key, data))) => match (KC::bytes_decode(key), DC::bytes_decode(data)) {
@@ -408,17 +398,7 @@ where
     }
 
     fn last(mut self) -> Option<Self::Item> {
-        let result = if self.move_on_first {
-            self.cursor.move_on_last(IM::MOVE_OPERATION)
-        } else {
-            match (self.cursor.current(), self.cursor.move_on_last(IM::MOVE_OPERATION)) {
-                (Ok(Some((ckey, _))), Ok(Some((key, data)))) if ckey != key => {
-                    Ok(Some((key, data)))
-                }
-                (Ok(_), Ok(_)) => Ok(None),
-                (Err(e), _) | (_, Err(e)) => Err(e),
-            }
-        };
+        let result = self.cursor.move_on_last(IM::MOVE_OPERATION);
 
         match result {
             Ok(Some((key, data))) => match (KC::bytes_decode(key), DC::bytes_decode(data)) {
@@ -525,17 +505,7 @@ where
     }
 
     fn last(mut self) -> Option<Self::Item> {
-        let result = if self.move_on_last {
-            self.cursor.move_on_first(IM::MOVE_OPERATION)
-        } else {
-            match (self.cursor.current(), self.cursor.move_on_first(IM::MOVE_OPERATION)) {
-                (Ok(Some((ckey, _))), Ok(Some((key, data)))) if ckey != key => {
-                    Ok(Some((key, data)))
-                }
-                (Ok(_), Ok(_)) => Ok(None),
-                (Err(e), _) | (_, Err(e)) => Err(e),
-            }
-        };
+        let result = self.cursor.move_on_first(IM::MOVE_OPERATION);
 
         match result {
             Ok(Some((key, data))) => match (KC::bytes_decode(key), DC::bytes_decode(data)) {
@@ -756,17 +726,7 @@ where
     }
 
     fn last(mut self) -> Option<Self::Item> {
-        let result = if self.move_on_last {
-            self.cursor.move_on_first(IM::MOVE_OPERATION)
-        } else {
-            match (self.cursor.current(), self.cursor.move_on_first(IM::MOVE_OPERATION)) {
-                (Ok(Some((ckey, _))), Ok(Some((key, data)))) if ckey != key => {
-                    Ok(Some((key, data)))
-                }
-                (Ok(_), Ok(_)) => Ok(None),
-                (Err(e), _) | (_, Err(e)) => Err(e),
-            }
-        };
+        let result = self.cursor.move_on_first(IM::MOVE_OPERATION);
 
         match result {
             Ok(Some((key, data))) => match (KC::bytes_decode(key), DC::bytes_decode(data)) {

--- a/heed/src/iterator/iter.rs
+++ b/heed/src/iterator/iter.rs
@@ -178,6 +178,9 @@ where
         }
     }
 
+    /// Returns the last entry in this iterater's range.
+    ///
+    /// If a last entry exists this will always return it, even if it has already been given with `next`.
     fn last(mut self) -> Option<Self::Item> {
         let result = self.cursor.move_on_last(IM::MOVE_OPERATION);
 
@@ -397,6 +400,9 @@ where
         }
     }
 
+    /// Returns the last entry in this iterater's range.
+    ///
+    /// If a last entry exists this will always return it, even if it has already been given with `next`.
     fn last(mut self) -> Option<Self::Item> {
         let result = self.cursor.move_on_last(IM::MOVE_OPERATION);
 
@@ -504,6 +510,9 @@ where
         }
     }
 
+    /// Returns the last entry in this iterater's range.
+    ///
+    /// If a last entry exists this will always return it, even if it has already been given with `next`.
     fn last(mut self) -> Option<Self::Item> {
         let result = self.cursor.move_on_first(IM::MOVE_OPERATION);
 
@@ -725,6 +734,9 @@ where
         }
     }
 
+    /// Returns the last entry in this iterater's range.
+    ///
+    /// If a last entry exists this will always return it, even if it has already been given with `next`.
     fn last(mut self) -> Option<Self::Item> {
         let result = self.cursor.move_on_first(IM::MOVE_OPERATION);
 

--- a/heed/src/iterator/mod.rs
+++ b/heed/src/iterator/mod.rs
@@ -227,7 +227,7 @@ mod tests {
         assert_eq!(iter.next().transpose().unwrap(), Some((2, ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((3, ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((4, ())));
-        assert_eq!(iter.last().transpose().unwrap(), None);
+        assert_eq!(iter.last().transpose().unwrap(), Some((4, ())));
 
         let mut iter = db.iter(&wtxn).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((1, ())));
@@ -235,7 +235,7 @@ mod tests {
         assert_eq!(iter.next().transpose().unwrap(), Some((3, ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((4, ())));
         assert_eq!(iter.next().transpose().unwrap(), None);
-        assert_eq!(iter.last().transpose().unwrap(), None);
+        assert_eq!(iter.last().transpose().unwrap(), Some((4, ())));
 
         wtxn.abort();
 
@@ -249,7 +249,7 @@ mod tests {
 
         let mut iter = db.iter(&wtxn).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((1, ())));
-        assert_eq!(iter.last().transpose().unwrap(), None);
+        assert_eq!(iter.last().transpose().unwrap(), Some((1, ())));
 
         wtxn.abort();
     }


### PR DESCRIPTION
# Pull Request

## What does this PR do?

From what I can tell in the `last` method for the iterators we are checking if the current key we are pointing at is equal to the last key so that if we have already gone through the iterator we return `None`. This doesn't work for dup tables though as the values may be different even if the key is the same (I added a test case that fails).

Although this PR removes this entirely, always returning a value for `last`, even if the iterator has already returned `None` from `next`. The main reason is this simpler and there is no requirement that once an iterator returns None that it wont return Some again: https://doc.rust-lang.org/std/iter/trait.Iterator.html#tymethod.next

Sorry if I missed something that makes this change invalid though! 
