### PR TITLE
preserve cmp functions with `DatabaseOpenOptions::types`

### DIFF
--- a/heed/src/databases/database.rs
+++ b/heed/src/databases/database.rs
@@ -79,7 +79,7 @@ impl<'e, 'n, T, KC, DC, C, CDUP> DatabaseOpenOptions<'e, 'n, T, KC, DC, C, CDUP>
     ///
     /// The default types are [`Unspecified`] and require a call to [`Database::remap_types`]
     /// to use the [`Database`].
-    pub fn types<NKC, NDC>(self) -> DatabaseOpenOptions<'e, 'n, T, NKC, NDC> {
+    pub fn types<NKC, NDC>(self) -> DatabaseOpenOptions<'e, 'n, T, NKC, NDC, C, CDUP> {
         DatabaseOpenOptions {
             env: self.env,
             types: Default::default(),

--- a/heed/src/databases/encrypted_database.rs
+++ b/heed/src/databases/encrypted_database.rs
@@ -77,7 +77,7 @@ impl<'e, 'n, T, KC, DC, C, CDUP> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC,
     ///
     /// The default types are [`Unspecified`] and require a call to [`Database::remap_types`]
     /// to use the [`Database`].
-    pub fn types<NKC, NDC>(self) -> EncryptedDatabaseOpenOptions<'e, 'n, T, NKC, NDC> {
+    pub fn types<NKC, NDC>(self) -> EncryptedDatabaseOpenOptions<'e, 'n, T, NKC, NDC, C, CDUP> {
         EncryptedDatabaseOpenOptions { inner: self.inner.types() }
     }
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?

Changes the  `DatabaseOpenOptions::types` method to preserve the compare functions on the database, currently it resets them to the default which can lead to some hard to debug issues if this is used after setting the cmp types.

