### PR TITLE
Opt heed crates into multi-target docs.rs builds

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -10,6 +10,21 @@ categories = ["database", "data-structures"]
 readme = "../README.md"
 edition = "2021"
 
+# Tell docs.rs which targets to build the documentation on. Since April
+# 2026, docs.rs only builds on x86_64-unknown-linux-gnu by default; opt
+# back into the platforms heed actually supports so the rendered docs
+# continue to show Windows-specific and macOS/iOS-specific items.
+# See <https://blog.rust-lang.org/2026/04/04/docsrs-only-default-targets/>.
+[package.metadata.docs.rs]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+
 [dependencies]
 bitflags = { version = "2.9.4", features = ["serde"] }
 byteorder = { version = "1.5.0", default-features = false }

--- a/heed3/Cargo.toml
+++ b/heed3/Cargo.toml
@@ -10,6 +10,21 @@ categories = ["database", "data-structures"]
 readme = "../README.md"
 edition = "2021"
 
+# Tell docs.rs which targets to build the documentation on. Since April
+# 2026, docs.rs only builds on x86_64-unknown-linux-gnu by default; opt
+# back into the platforms heed3 actually supports so the rendered docs
+# continue to show Windows-specific and macOS/iOS-specific items.
+# See <https://blog.rust-lang.org/2026/04/04/docsrs-only-default-targets/>.
+[package.metadata.docs.rs]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+
 [dependencies]
 aead = { version = "0.5.2", default-features = false }
 bitflags = { version = "2.6.0", features = ["serde"] }

--- a/lmdb-master-sys/Cargo.toml
+++ b/lmdb-master-sys/Cargo.toml
@@ -16,6 +16,19 @@ keywords = ["LMDB", "database", "storage-engine", "bindings", "library"]
 categories = ["database", "external-ffi-bindings"]
 edition = "2021"
 
+# Tell docs.rs which targets to build the documentation on. Since April
+# 2026, docs.rs only builds on x86_64-unknown-linux-gnu by default; opt
+# back into the platforms this crate supports.
+# See <https://blog.rust-lang.org/2026/04/04/docsrs-only-default-targets/>.
+[package.metadata.docs.rs]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+
 # NB: Use "--features bindgen" to generate bindings.
 build = "build.rs"
 

--- a/lmdb-master3-sys/Cargo.toml
+++ b/lmdb-master3-sys/Cargo.toml
@@ -16,6 +16,19 @@ keywords = ["LMDB", "database", "storage-engine", "bindings", "library"]
 categories = ["database", "external-ffi-bindings"]
 edition = "2021"
 
+# Tell docs.rs which targets to build the documentation on. Since April
+# 2026, docs.rs only builds on x86_64-unknown-linux-gnu by default; opt
+# back into the platforms this crate supports.
+# See <https://blog.rust-lang.org/2026/04/04/docsrs-only-default-targets/>.
+[package.metadata.docs.rs]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+
 # NB: Use "--features bindgen" to generate bindings.
 build = "build.rs"
 


### PR DESCRIPTION
## Summary

- docs.rs now only builds on \`x86_64-unknown-linux-gnu\` by default (see [the April 2026 announcement](https://blog.rust-lang.org/2026/04/04/docsrs-only-default-targets/)). heed and heed3 expose Windows- and macOS/iOS-specific items (e.g. the \`posix-sem\` feature, \`url\`-based Windows path handling), so the rendered docs would silently lose them on every release.
- Adds a \`[package.metadata.docs.rs]\` block to \`heed\`, \`heed3\`, \`lmdb-master-sys\`, and \`lmdb-master3-sys\` opting into the tier-1 targets the crates actually support: x86_64 and aarch64 Linux, x86_64 and aarch64 macOS, and x86_64 Windows.
- \`heed\` and \`heed3\` additionally request \`all-features = true\` so the optional serde / encryption items keep appearing in the API reference.

Closes #363.

## Test plan

- [x] \`cargo metadata --no-deps --format-version 1 | jq '.packages[] | select(.name==\"heed\") | .metadata'\` reflects the new targets list.
- [ ] Verify on docs.rs after the next release that the Windows-only / macOS-only items render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)