### PR TITLE
Add serde-wincode as an alternative to bincode

### DIFF
--- a/heed-types/Cargo.toml
+++ b/heed-types/Cargo.toml
@@ -14,13 +14,15 @@ byteorder = "1.5.0"
 heed-traits = { version = "0.20.0", path = "../heed-traits" }
 serde = { version = "1.0.223", optional = true }
 serde_json = { version = "1.0.145", optional = true }
+serde-wincode = { version = "0.1.2", optional = true }
 rmp-serde = { version = "1.3.0", optional = true }
 
 [features]
-default = ["serde-bincode", "serde-json"]
-serde-bincode = ["serde", "bincode"]
-serde-json = ["serde", "serde_json"]
-serde-rmp = ["serde", "rmp-serde"]
+default = ["serde-json", "serde-wincode"]
+serde-bincode = ["dep:serde", "bincode"]
+serde-json = ["dep:serde", "serde_json"]
+serde-rmp = ["dep:serde", "rmp-serde"]
+serde-wincode = ["dep:serde", "dep:serde-wincode"]
 # serde_json features
 preserve_order = ["serde_json/preserve_order"]
 arbitrary_precision = ["serde_json/arbitrary_precision"]

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -25,15 +25,24 @@ mod serde_json;
 #[cfg(feature = "serde-rmp")]
 mod serde_rmp;
 
+#[cfg(feature = "serde-wincode")]
+mod serde_wincode;
+
 pub use self::bytes::Bytes;
 pub use self::decode_ignore::DecodeIgnore;
 pub use self::integer::*;
 pub use self::lazy_decode::{Lazy, LazyDecode};
 #[cfg(feature = "serde-bincode")]
+#[deprecated(
+    note = "The `bincode` crate is unmaintained. Use `SerdeWincode` instead.",
+    since = "0.23.0"
+)]
 pub use self::serde_bincode::SerdeBincode;
 #[cfg(feature = "serde-json")]
 pub use self::serde_json::SerdeJson;
 #[cfg(feature = "serde-rmp")]
 pub use self::serde_rmp::SerdeRmp;
+#[cfg(feature = "serde-wincode")]
+pub use self::serde_wincode::SerdeWincode;
 pub use self::str::Str;
 pub use self::unit::Unit;

--- a/heed-types/src/serde_wincode.rs
+++ b/heed-types/src/serde_wincode.rs
@@ -1,0 +1,41 @@
+use std::borrow::Cow;
+
+use heed_traits::{BoxedError, BytesDecode, BytesEncode};
+use serde::{Deserialize, Serialize};
+use serde_wincode::SerdeCompat;
+
+/// Describes a type that is [`Serialize`]/[`Deserialize`] and uses `wincode` to do so.
+///
+/// It can borrow bytes from the original slice.
+pub struct SerdeWincode<T>(std::marker::PhantomData<T>);
+
+impl<'a, T: 'a> BytesEncode<'a> for SerdeWincode<T>
+where
+    T: Serialize,
+{
+    type EItem = T;
+
+    fn bytes_encode(item: &'a Self::EItem) -> Result<Cow<'a, [u8]>, BoxedError> {
+        use serde_wincode::wincode::Serialize;
+        match SerdeCompat::<T>::serialize(item) {
+            Ok(bytes) => Ok(Cow::Owned(bytes)),
+            Err(err) => Err(err.into()),
+        }
+    }
+}
+
+impl<'a, T: 'a> BytesDecode<'a> for SerdeWincode<T>
+where
+    T: Deserialize<'a>,
+{
+    type DItem = T;
+
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
+        use serde_wincode::wincode::Deserialize;
+        SerdeCompat::<T>::deserialize(bytes).map_err(BoxedError::from)
+    }
+}
+
+unsafe impl<T> Send for SerdeWincode<T> {}
+
+unsafe impl<T> Sync for SerdeWincode<T> {}

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -51,13 +51,14 @@ url = "2.5.7"
 [features]
 # The `serde` feature makes some types serializable,
 # like the `EnvOpenOptions` struct.
-default = ["serde", "serde-bincode", "serde-json"]
+default = ["serde", "serde-json", "serde-wincode"]
 serde = ["bitflags/serde", "dep:serde"]
 
-# Enable the serde en/decoders for bincode, serde_json, or rmp_serde
+# Enable the serde en/decoders for bincode, serde_json, rmp_serde, or wincode
 serde-bincode = ["heed-types/serde-bincode"]
 serde-json = ["heed-types/serde-json"]
 serde-rmp = ["heed-types/serde-rmp"]
+serde-wincode = ["heed-types/serde-wincode"]
 
 # serde_json features
 preserve_order = ["heed-types/preserve_order"]

--- a/heed/examples/all-types.rs
+++ b/heed/examples/all-types.rs
@@ -32,14 +32,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let mut wtxn = env.write_txn()?;
-    let db: Database<Str, SerdeBincode<Hello>> =
-        env.create_database(&mut wtxn, Some("serde-bincode"))?;
+    let db: Database<Str, SerdeWincode<Hello>> =
+        env.create_database(&mut wtxn, Some("serde-wincode"))?;
 
     let hello = Hello { string: "hi" };
     db.put(&mut wtxn, "hello", &hello)?;
 
     let ret: Option<Hello> = db.get(&wtxn, "hello")?;
-    println!("serde-bincode:\t{:?}", ret);
+    println!("serde-wincode:\t{:?}", ret);
 
     wtxn.commit()?;
 


### PR DESCRIPTION
## What does this PR do?
This PR adds `serde-wincode` as an alternative to bincode, which is considered deprecated. `serde-wincode` is intended to be a drop-in replacement for `bincode`'s `serde` compatibility.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
